### PR TITLE
A bunch of lodash deps

### DIFF
--- a/src/dependecies/index.ts
+++ b/src/dependecies/index.ts
@@ -1,0 +1,30 @@
+import { Dependency } from "../shared/types";
+import { lodashDeps } from "./lodash";
+
+export const deps = new Map<string, Dependency>([
+  [
+    "object-assign",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "Object.assign",
+      message: "Use native Object.assign",
+    },
+  ],
+  [
+    "object.assign",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "Object.assign",
+      message: "Use native Object.assign",
+    },
+  ],
+  [
+    "es6-object-assign",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "Object.assign",
+      message: "Use native Object.assign",
+    },
+  ],
+  ...lodashDeps,
+]);

--- a/src/dependecies/lodash/index.ts
+++ b/src/dependecies/lodash/index.ts
@@ -1,34 +1,6 @@
-type Dep = {
-  minimalNodeVersion: string;
-  message: string;
-  nativeApi: string;
-};
+import {Dependency} from "../../shared/types";
 
-export const deps = new Map<string, Dep>([
-  [
-    "object-assign",
-    {
-      minimalNodeVersion: "4.0.0",
-      nativeApi: "Object.assign",
-      message: "Use native Object.assign",
-    },
-  ],
-  [
-    "object.assign",
-    {
-      minimalNodeVersion: "4.0.0",
-      nativeApi: "Object.assign",
-      message: "Use native Object.assign",
-    },
-  ],
-  [
-    "es6-object-assign",
-    {
-      minimalNodeVersion: "4.0.0",
-      nativeApi: "Object.assign",
-      message: "Use native Object.assign",
-    },
-  ],
+export const lodashDeps = new Map<string, Dependency>([
   [
     "lodash.compact",
     {
@@ -254,4 +226,212 @@ export const deps = new Map<string, Dep>([
       message: "array.filter(el => !values.includes(el))",
     },
   ],
-]);
+  [
+    "lodash.uniq",
+    {
+      minimalNodeVersion: "0.12.0",
+      nativeApi: "Set",
+      message: "const uniq = [...new Set([1, 1, 2])]",
+    },
+  ],
+  [
+    "lodash.bind",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Function.prototype.bind",
+      message: "yourFunction.bind(scope)"
+    }
+  ],
+  [
+    "lodash.isfunction",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "typeof",
+      message: "typeof yourFunction === 'function'"
+    }
+  ],
+  [
+    "lodash.castarray",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Array.isArray & array",
+      message: "Array.isArray(arr) ? arr : [arr]"
+    }
+  ],
+  [
+    "lodash.gt",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "'Greater than' operator",
+      message: "Use native 'Greater than' (>) operator"
+    }
+  ],
+  [
+    "lodash.gte",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "'Greater than or equal' operator",
+      message: "Use native 'Greater than or equal' (>=) operator"
+    }
+  ],
+  [
+    "lodash.isfinite",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Number.isFinite",
+      message: "Number.isFinite(num)"
+    }
+  ],
+  [
+    "lodash.isinteger",
+    {
+      minimalNodeVersion: "0.12.0",
+      nativeApi: "Number.isInteger",
+      message: "Number.isInteger(num)"
+    }
+  ],
+  [
+    "lodash.isnan",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Number.isNan",
+      message: "Number.isNan(num)"
+    }
+  ],
+  [
+    "lodash.isnil",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Equality operator",
+      message: "someData == null"
+    }
+  ],
+  [
+    "lodash.isnull",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Strict equality operator",
+      message: "someData === null"
+    }
+  ],
+  [
+    "lodash.isundefined",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Strict equality operator",
+      message: "someData === undefined"
+    }
+  ],
+  [
+    "lodash.keys",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "Object.keys",
+      message: "Object.keys({ a: 1, b: 2})"
+    }
+  ],
+  [
+    "lodash.values",
+    {
+      minimalNodeVersion: "7.0.0",
+      nativeApi: "Object.values",
+      message: "Object.values({ a: 1, b: 2})"
+    }
+  ],
+  [
+    "lodash.endswith",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "String.prototype.endsWith",
+      message: "'foobar'.endsWith('bar')"
+    }
+  ],
+  [
+    "lodash.padstart",
+    {
+      minimalNodeVersion: "8.0.0",
+      nativeApi: "String.prototype.padStart",
+      message: "'oo'.padStart(3, 'f')"
+    }
+  ],
+  [
+    "lodash.padend",
+    {
+      minimalNodeVersion: "8.0.0",
+      nativeApi: "String.prototype.padEnd",
+      message: "'f'.padEnd(3, 'o')"
+    }
+  ],
+  [
+    "lodash.repeat",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "String.prototype.repeat",
+      message: "'foo'.repeat(3)"
+    }
+  ],
+  [
+    "lodash.split",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "String.prototype.split",
+      message: "'foo,bar'.split(',')"
+    }
+  ],
+  [
+    "lodash.startswith",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "String.prototype.startsWith",
+      message: "'foobar'.startsWith('foo')"
+    }
+  ],
+  [
+    "lodash.tolower",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "String.prototype.toLowerCase",
+      message: "'FOOBAR'.toLowerCase()"
+    }
+  ],
+  [
+    "lodash.toupper",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "String.prototype.toUpperCase",
+      message: "'foobar'.toUpperCase()"
+    }
+  ],
+  [
+    "lodash.trim",
+    {
+      minimalNodeVersion: "0.10.0",
+      nativeApi: "String.prototype.trim",
+      message: "' foobar '.trim()"
+    }
+  ],
+  [
+    "lodash.trimstart",
+    {
+      minimalNodeVersion: "10.0.0",
+      nativeApi: "String.prototype.trimStart",
+      message: "' foobar '.trimStart()"
+    }
+  ],
+  [
+    "lodash.trimend",
+    {
+      minimalNodeVersion: "10.0.0",
+      nativeApi: "String.prototype.trimend",
+      message: "' foobar '.trimEnd()"
+    }
+  ],
+  [
+    "lodash.times",
+    {
+      minimalNodeVersion: "4.0.0",
+      nativeApi: "Array.from with callback",
+      message: "Array.from({ length: 5 }, (_, x) => x)"
+    }
+  ],
+])

--- a/src/findUselessPackages.test.ts
+++ b/src/findUselessPackages.test.ts
@@ -1,47 +1,17 @@
 import { describe, expect, test } from "vitest";
 import { findUselessPackages } from "./findUselessPackages.js";
+import { deps } from "./dependecies";
 
 describe("findUselessPackages", () => {
   test("have useless deps only with node@lts", () => {
-    const deps = new Set([
-      "object-assign",
-      "object.assign",
-      "es6-object-assign",
-      "lodash.compact",
-      "lodash.isarray",
-      "lodash.concat",
-      "lodash.difference",
-      "lodash.differenceby",
-      "lodash.differencewith",
-      "lodash.drop",
-      "lodash.dropright",
-      "lodash.join",
-      "lodash.reverse",
-      "lodash.lastindexof",
-      "lodash._slice",
-      "lodash.slice",
-      "lodash.without",
-      "lodash.findindex",
-      "lodash.findlastindex",
-      "lodash.head",
-      "lodash.flatten",
-      "lodash.flattendeep",
-      "lodash.flattendepth",
-      "lodash.frompairs",
-      "lodash.indexof",
-      "lodash.fill",
-      "lodash.initial",
-      "lodash.last",
-      "lodash.nth",
-      "lodash.pull",
-      "lodash.pullall",
-    ]);
+    const depsNames = new Set([...deps.keys()])
+
     const uselessPackages = findUselessPackages({
-      dependencies: deps,
+      dependencies: depsNames,
       nodeVersion: "20.99.0",
     });
 
-    expect(uselessPackages).toEqual(deps);
+    expect(uselessPackages).toEqual(depsNames);
   });
 
   test("have mixed deps", () => {

--- a/src/findUselessPackages.ts
+++ b/src/findUselessPackages.ts
@@ -1,5 +1,5 @@
-import { deps } from "./deps.js";
 import { gte, SemVer } from "semver";
+import { deps } from "./dependecies";
 
 type FindUselessPackages = {
   nodeVersion: SemVer | string;

--- a/src/run.ts
+++ b/src/run.ts
@@ -3,8 +3,8 @@ import { existsSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 import { parsePackageJson } from "./parsePackageJson.js";
 import { findUselessPackages } from "./findUselessPackages.js";
-import { deps } from "./deps.js";
 import { minVersion } from "semver";
+import { deps } from "./dependecies";
 
 const argv = yargs(process.argv.slice(2))
   .options({

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1,0 +1,5 @@
+export type Dependency = {
+  minimalNodeVersion: string;
+  message: string;
+  nativeApi: string;
+};


### PR DESCRIPTION
# Features:
- [lodash.uniq](https://www.npmjs.com/package/lodash.uniq) - can be replaced with [Set API](https://developer.mozilla.org/ru/docs/Web/JavaScript/Reference/Global_Objects/Set). Available from [0.12.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set#browser_compatibility)
- [lodash.bind](https://www.npmjs.com/package/lodash.bind) - can be replaced with [Function.prototype.bind](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/bind#browser_compatibility)
- [lodash.isfunction](https://www.npmjs.com/package/lodash.isfunction) - can be replaced with simple [typeof](https://www.npmjs.com/package/lodash.isfunction) operator. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#browser_compatibility)
- [lodash.castarray](https://www.npmjs.com/package/lodash.castarray) - can be replaced with [Array.isArray](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/isArray#browser_compatibility)
- [lodash.gt](https://www.npmjs.com/package/lodash.gt) - can be replaced with [Greater than](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than) operator. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than#browser_compatibility)
- [lodash.gte ](https://www.npmjs.com/package/lodash.gte) - can be replaced with [Greater than or equal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal) operator. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Greater_than_or_equal#browser_compatibility)
- [lodash.isfinite](https://www.npmjs.com/package/lodash.isfinite) - can be replaced with [Number.isFinite](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite) method. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isFinite#browser_compatibility)
- [lodash.isinteger](https://www.npmjs.com/package/lodash.isinteger)  - can be replaced with [Number.isInteger](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger) method. Available from [0.12.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isInteger#browser_compatibility)
- [lodash.isnan](https://www.npmjs.com/package/lodash.isnan) - can be replaced with [Number.isNan](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN) method. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Number/isNaN)
- [lodash.isnil](https://www.npmjs.com/package/lodash.isnil) - can be replaced with [Equality operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Equality#browser_compatibility)
- [lodash.isnull](https://www.npmjs.com/package/lodash.isnull) - can be replaced with [Strict equality operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality#browser_compatibility)
- [lodash.isundefined](https://www.npmjs.com/package/lodash.isundefined) - can be replaced with [Strict equality operator](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Strict_equality#browser_compatibility)
- [lodash.keys](https://www.npmjs.com/package/lodash.keys) - can be replaced with [Object.keys](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/keys#browser_compatibility)
- [lodash.values](https://www.npmjs.com/package/lodash.values) - can be replaced with [Object.values](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values). Available from [7.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/values#browser_compatibility)
- [lodash.endswith](https://www.npmjs.com/package/lodash.endswith) - can be replaced with [String.prototype.endsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith) method. Available from [4.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/endsWith#browser_compatibility)
- [lodash.padstart](https://www.npmjs.com/package/lodash.padstart) - can be replaced with [String.prototype.padStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart) method. Available from [8.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padStart#browser_compatibility)
- [lodash.padend](https://www.npmjs.com/package/lodash.padend) - can be replaced with [String.prototype.padEnd](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd) method. Available from [8.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/padEnd#browser_compatibility)
- [lodash.repeat](https://www.npmjs.com/package/lodash.repeat) - can be replaced with [String.prototype.repeat](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat) method. Available from [4.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/repeat#browser_compatibility)
- [lodash.split](https://www.npmjs.com/package/lodash.split) - can be replaced with [String.prototype.split](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split) method. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/split#browser_compatibility)
- [lodash.startswith](https://www.npmjs.com/package/lodash.startswith) - can be replaced with [String.prototype.startsWith](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith). Available from [4.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith#browser_compatibility)
- [lodash.tolower](https://www.npmjs.com/package/lodash.tolower) - can be replaced with [String.prototype.toLowerCase](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase) method. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toLowerCase#browser_compatibility)
- [lodash.toupper](https://www.npmjs.com/package/lodash.toupper) - can be replaced with [String.prototype.toUpperCase](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase) method. Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/toUpperCase#browser_compatibility)
- [lodash.trim](https://www.npmjs.com/package/lodash.trim) - can be replaced with [String.prototype.trim](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim). Available from [0.10.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trim#browser_compatibility)
- [lodash.trimstart](https://www.npmjs.com/package/lodash.trimstart) - can be replaced with [String.prototype.trimStart](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart) method. Available from [10.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimStart#browser_compatibility)
- [lodash.trimend](https://www.npmjs.com/package/lodash.trimend) - can be replaced with [String.prototype.trimEnd](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd). Available from [10.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/trimEnd#browser_compatibility)
- [lodash.times](https://www.npmjs.com/package/lodash.times) - can be replaced with [Array.from](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from) method with callback. Available from [4.0.0](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/from#browser_compatibility)

## Refactor:
- Add 'shared' folder 
- split deps into separate folders, because.. because just look at the number of dependencies

BTW, how about adding an MDN link for each of our deps? User will be able to click on it and open browser with docs about this native API.